### PR TITLE
Changes to the spam command (Take 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,8 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# .vscode/ to remove files created by vscode when editing
+# .DS_Store is a local file for mac that doesn't need to be added to the GitHub.
+\.DS_Store
+.vscode/

--- a/bot.py
+++ b/bot.py
@@ -32,11 +32,14 @@ async def on_command_error(ctx: commands.Context, error):
     elif isinstance(error, commands.BotMissingPermissions):
         BotLogs.error(f"Encountered a permissions error while executing {ctx.command}")
         await ctx.send(error)
+
     elif isinstance(error, commands.DisabledCommand):
         await ctx.send("Sorry. This command is disabled and cannot be used.")
     elif isinstance(error, commands.CheckFailure):
         if ctx.command.qualified_name is not "latest":
             await ctx.send(":lock: You do not have the required permissions to run this command")
+    elif isinstance(error, commands.CommandOnCooldown):
+        await ctx.send(error)
     elif isinstance(error, commands.MissingRequiredArgument):
         await ctx.send(f"You are missing a required argument!(See {ctx.prefix}help {ctx.command.qualified_name} for info on how to use this command)")
     elif isinstance(error, commands.BadArgument):

--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,5 @@
-import asyncio 
+#!/usr/bin/env python3
+import asyncio
 import datetime
 import discord
 import configparser

--- a/cogs/basic.py
+++ b/cogs/basic.py
@@ -128,17 +128,14 @@ class basic:
     @command.cooldown(1, 30, BucketType.user)
     async def spam(self,ctx,amount:int=None):
         limit = 50
-        halflimit = limit / 2
         if amount is not None:
             if amount > limit:
                 await ctx.send('Hey! You trying to ratelimit me?! Keep it under {limit}.'.format(limit=limit))
-        else:
-            while amount > 0:
-                if amount < halflimit:
-                    ctx.command.reset_cooldown(ctx)
-                await ctx.send("You have requested spam.")
-                await asyncio.sleep(5)
-                amount -= 1
+            else:
+                while amount > 0:
+                    await ctx.send("You have requested spam.")
+                    await asyncio.sleep(5)
+                    amount -= 1
         else:
             await ctx.send("You have requested spam.")
             await asyncio.sleep(5)

--- a/cogs/basic.py
+++ b/cogs/basic.py
@@ -125,13 +125,17 @@ class basic:
 
     @commands.command()
     @commands.guild_only()
+    @command.cooldown(1, 30, BucketType.user)
     async def spam(self,ctx,amount:int=None):
         limit = 50
+        halflimit = limit / 2
         if amount is not None:
             if amount > limit:
                 await ctx.send('Hey! You trying to ratelimit me?! Keep it under {limit}.'.format(limit=limit))
         else:
             while amount > 0:
+                if amount < halflimit:
+                    ctx.command.reset_cooldown(ctx)
                 await ctx.send("You have requested spam.")
                 await asyncio.sleep(5)
                 amount -= 1

--- a/cogs/basic.py
+++ b/cogs/basic.py
@@ -1,5 +1,5 @@
 import discord
-import time 
+import time
 import asyncio
 import datetime
 from discord.ext import commands
@@ -27,7 +27,7 @@ class basic:
             except discord.Forbidden:
                 await ctx.send("Are you sure I have permission to do this?")
                 return
-        else: 
+        else:
             await ctx.send("I can't just send an empty embed, bro.")
             return
 
@@ -41,7 +41,7 @@ class basic:
         else:
             await ctx.message.author.remove_roles(role)
             await ctx.send(f"Successfully left {role.name}!")
-    
+
     @commands.command()
     @commands.guild_only()
     async def mac(self, ctx):
@@ -52,7 +52,7 @@ class basic:
         else:
             await ctx.message.author.remove_roles(role)
             await ctx.send(f"Successfully left {role.name}!")
-    
+
     @commands.command()
     @commands.guild_only()
     async def ios(self, ctx):
@@ -125,29 +125,37 @@ class basic:
 
     @commands.command()
     @commands.guild_only()
-    async def spam(self,ctx):
-        await ctx.send("You have requested spam.")
-        await asyncio.sleep(5)
-        await ctx.send("You have requested spam.")
-        await asyncio.sleep(5)
-        await ctx.send("You have requested spam.")
-        await asyncio.sleep(5)
-        await ctx.send("You have requested spam.")
-        await asyncio.sleep(5)
-        await ctx.send("You have requested spam.")
-        await asyncio.sleep(5)
-        await ctx.send("You have requested spam.")
-        await asyncio.sleep(5)
-        await ctx.send("You have requested spam.")
-        await asyncio.sleep(5)
-        await ctx.send("You have requested spam.")
-        await asyncio.sleep(5)
-        await ctx.send("You have requested spam.")
-        await asyncio.sleep(5)
-        await ctx.send("You have requested spam.")
+    async def spam(self,ctx,amount:int=None):
+        limit = 50
+        if amount is not None:
+            if amount > limit:
+                await ctx.send('Hey! You trying to ratelimit me?! Keep it under {limit}.'.format(limit=limit))
+        else:
+            while amount > 0:
+                await ctx.send("You have requested spam.")
+                await asyncio.sleep(5)
+                amount -= 1
+        else:
+            await ctx.send("You have requested spam.")
+            await asyncio.sleep(5)
+            await ctx.send("You have requested spam.")
+            await asyncio.sleep(5)
+            await ctx.send("You have requested spam.")
+            await asyncio.sleep(5)
+            await ctx.send("You have requested spam.")
+            await asyncio.sleep(5)
+            await ctx.send("You have requested spam.")
+            await asyncio.sleep(5)
+            await ctx.send("You have requested spam.")
+            await asyncio.sleep(5)
+            await ctx.send("You have requested spam.")
+            await asyncio.sleep(5)
+            await ctx.send("You have requested spam.")
+            await asyncio.sleep(5)
+            await ctx.send("You have requested spam.")
+            await asyncio.sleep(5)
+            await ctx.send("You have requested spam.")
 
-            
-            
 
 def setup(bot):
     bot.add_cog(basic(bot))


### PR DESCRIPTION
Spam will now add a limit of 50 messages, every 5 seconds to avoid ratelimit, and a cooldown if above 25. If a spam amount is not given, it defaults to 10. Some other things changed as well.